### PR TITLE
Add optional `dateLocale` for localized date labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Parameter | Description |
 `type`| Chart type. Supported types: `line`, `area`, `bar`, `step`, `pie`, `donut`
 `labels`| Array of UNIX timestamps in milliseconds, or arbitrary strings for text labels
 `labelType`| Optional X-axis label kind: `year`, `month`, `week`, `day`, `hour`, `5min`, `dayHour` or `text`. When omitted, it is inferred from the first two `labels` records: strings → `text`, timestamps → `year`/`month`/`week`/`day`/`hour`/`5min` depending on the step between them. `year` labels render as `2026`, `month` as `January`, `week` as `Week 1` (week of the year). Charts with `text` labels show no header caption.
+`dateLocale`| Optional localized date strings for axis, tooltip and caption labels: `{ months, monthsFull, weekDays, weekDaysShort }`. Each field is an optional array (12 months, or 7 weekdays starting Sunday) and falls back to English when omitted.
 `datasets`| Array of params for each dataset
 `datasets[*].name`| Dataset name
 `datasets[*].color`| Dataset color

--- a/src/Tooltip.ts
+++ b/src/Tooltip.ts
@@ -355,9 +355,9 @@ export class Tooltip {
   #getTitle(data: AnalyzedData, labelIndex: number): string {
     switch (data.tooltipFormatter) {
       case 'statsFormatDayHourFull':
-        return formatDayHourFull(data.xLabels[labelIndex].value);
+        return formatDayHourFull(data.xLabels[labelIndex].value, data.dateLocale);
       case 'statsTooltipFormat(\'day\')':
-        return getLabelDate(data.xLabels[labelIndex], { withYear: true });
+        return getLabelDate(data.xLabels[labelIndex], { withYear: true }, data.dateLocale);
       case 'statsTooltipFormat(\'hour\')':
       case 'statsTooltipFormat(\'5min\')':
         return getLabelTime(data.xLabels[labelIndex]);

--- a/src/Zoomer.ts
+++ b/src/Zoomer.ts
@@ -212,7 +212,7 @@ export class Zoomer {
       });
 
       if (zoomInLabel) {
-        this.#header.zoom(getFullLabelDate(zoomInLabel));
+        this.#header.zoom(getFullLabelDate(zoomInLabel, {}, this.#data.dateLocale));
       }
 
       this.#isZoomed = !this.#isZoomed;

--- a/src/data.ts
+++ b/src/data.ts
@@ -40,7 +40,7 @@ const LABEL_TYPE_TO_FORMATTER: Record<LabelType, string | undefined> = {
 
 export function analyzeData(data: LovelyChartParams, fallbackLabelType?: LabelType): AnalyzedData {
   const {
-    title, labelFormatter: labelFormatterRaw, tooltipFormatter, isStacked, isPercentage, secondaryYAxis,
+    title, labelFormatter: labelFormatterRaw, tooltipFormatter, dateLocale, isStacked, isPercentage, secondaryYAxis,
     hasSecondYAxis, onZoom, noZoom, zoomType, withMinimap, minimapRange, noCaption, zoomOutLabel,
     valuePrefix, valueSuffix, isCurrencyPrefix, limitDate, onLimitedRangeClick,
   } = data;
@@ -72,16 +72,16 @@ export function analyzeData(data: LovelyChartParams, fallbackLabelType?: LabelTy
       xLabels = formatYear(labels as number[]);
       break;
     case 'statsFormatMonth':
-      xLabels = formatMonth(labels as number[]);
+      xLabels = formatMonth(labels as number[], dateLocale);
       break;
     case 'statsFormatWeek':
       xLabels = formatWeek(labels as number[]);
       break;
     case 'statsFormatDayHour':
-      xLabels = formatDayHour(labels as number[]);
+      xLabels = formatDayHour(labels as number[], dateLocale);
       break;
     case 'statsFormat(\'day\')':
-      xLabels = formatDay(labels as number[]);
+      xLabels = formatDay(labels as number[], dateLocale);
       break;
     case 'statsFormat(\'hour\')':
     case 'statsFormat(\'5min\')':
@@ -107,6 +107,7 @@ export function analyzeData(data: LovelyChartParams, fallbackLabelType?: LabelTy
     labelType,
     labelFormatter,
     tooltipFormatter,
+    dateLocale,
     xLabels,
     datasets,
     isStacked,

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,31 +1,34 @@
-import type { XLabel } from './types';
+import type { DateLocale, XLabel } from './types';
 
 import {
   MILLISECONDS_IN_DAY, MILLISECONDS_IN_WEEK, MONTHS, MONTHS_FULL, WEEK_DAYS, WEEK_DAYS_SHORT,
 } from './constants';
 
-export function formatDayHour(labels: number[]): XLabel[] {
+export function formatDayHour(labels: number[], dateLocale?: DateLocale): XLabel[] {
+  const months = dateLocale?.months ?? MONTHS;
   return labels.map((value) => {
     const date = new Date(value);
     const hours = String(date.getHours()).padStart(2, '0');
     return {
       value,
-      text: `${date.getDate()} ${MONTHS[date.getMonth()]} ${hours}:00`,
+      text: `${date.getDate()} ${months[date.getMonth()]} ${hours}:00`,
     };
   });
 }
 
-export function formatDayHourFull(value: number): string {
+export function formatDayHourFull(value: number, dateLocale?: DateLocale): string {
+  const months = dateLocale?.months ?? MONTHS;
   const date = new Date(value);
   const hours = String(date.getHours()).padStart(2, '0');
-  return `${date.getDate()} ${MONTHS[date.getMonth()]} ${hours}:00`;
+  return `${date.getDate()} ${months[date.getMonth()]} ${hours}:00`;
 }
 
-export function formatDay(labels: number[]): XLabel[] {
+export function formatDay(labels: number[], dateLocale?: DateLocale): XLabel[] {
+  const months = dateLocale?.months ?? MONTHS;
   return labels.map((value) => {
     const date = new Date(value);
     const day = date.getDate();
-    const month = MONTHS[date.getMonth()];
+    const month = months[date.getMonth()];
 
     return ({
       value,
@@ -57,10 +60,11 @@ function getIsoWeek(value: number): number {
   return Math.floor((thursday - yearStart) / MILLISECONDS_IN_WEEK) + 1;
 }
 
-export function formatMonth(labels: number[]): XLabel[] {
+export function formatMonth(labels: number[], dateLocale?: DateLocale): XLabel[] {
+  const monthsFull = dateLocale?.monthsFull ?? MONTHS_FULL;
   return labels.map((value) => ({
     value,
-    text: MONTHS_FULL[new Date(value).getUTCMonth()],
+    text: monthsFull[new Date(value).getUTCMonth()],
   }));
 }
 
@@ -128,8 +132,10 @@ interface LabelDateOptions {
   withHours?: boolean;
 }
 
-export function getFullLabelDate(label: XLabel, { isShort = false }: LabelDateOptions = {}): string {
-  return getLabelDate(label, { isShort, withWeekDay: true, withYear: true, omitCurrentYear: true });
+export function getFullLabelDate(
+  label: XLabel, { isShort = false }: LabelDateOptions = {}, dateLocale?: DateLocale,
+): string {
+  return getLabelDate(label, { isShort, withWeekDay: true, withYear: true, omitCurrentYear: true }, dateLocale);
 }
 
 export function getLabelDate(
@@ -137,13 +143,17 @@ export function getLabelDate(
   {
     isShort = false, withWeekDay = false, withYear = false, omitCurrentYear = false, withHours = false,
   }: LabelDateOptions = {},
+  dateLocale?: DateLocale,
 ): string {
   const { value } = label;
   const date = new Date(value);
-  const weekDaysArray = isShort ? WEEK_DAYS_SHORT : WEEK_DAYS;
+  const months = dateLocale?.months ?? MONTHS;
+  const weekDaysArray = isShort
+    ? (dateLocale?.weekDaysShort ?? WEEK_DAYS_SHORT)
+    : (dateLocale?.weekDays ?? WEEK_DAYS);
   const year = date.getUTCFullYear();
 
-  let string = `${date.getUTCDate()} ${MONTHS[date.getUTCMonth()]}`;
+  let string = `${date.getUTCDate()} ${months[date.getUTCMonth()]}`;
   if (withWeekDay) {
     string = `${weekDaysArray[date.getUTCDay()]}, ` + string;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,10 +51,10 @@ export interface LovelyChartDatasetParams {
 
 /** Localized date strings for axis, tooltip and caption labels. Each is optional and falls back to English. */
 export interface DateLocale {
-  months?: readonly string[]; // short month names, 12 entries (Jan..Dec)
-  monthsFull?: readonly string[]; // full month names, 12 entries (January..December)
-  weekDays?: readonly string[]; // full weekday names, 7 entries starting Sunday
-  weekDaysShort?: readonly string[]; // short weekday names, 7 entries starting Sunday
+  months?: readonly string[]; // Short month names, 12 entries (Jan..Dec)
+  monthsFull?: readonly string[]; // Full month names, 12 entries (January..December)
+  weekDays?: readonly string[]; // Full weekday names, 7 entries starting Sunday
+  weekDaysShort?: readonly string[]; // Short weekday names, 7 entries starting Sunday
 }
 
 /** Raw data accepted by the `LovelyChart` constructor and `onZoom` callbacks. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,14 @@ export interface LovelyChartDatasetParams {
   values: (number | null)[];
 }
 
+/** Localized date strings for axis, tooltip and caption labels. Each is optional and falls back to English. */
+export interface DateLocale {
+  months?: readonly string[]; // short month names, 12 entries (Jan..Dec)
+  monthsFull?: readonly string[]; // full month names, 12 entries (January..December)
+  weekDays?: readonly string[]; // full weekday names, 7 entries starting Sunday
+  weekDaysShort?: readonly string[]; // short weekday names, 7 entries starting Sunday
+}
+
 /** Raw data accepted by the `LovelyChart` constructor and `onZoom` callbacks. */
 export interface LovelyChartParams {
   type: ChartType;
@@ -59,6 +67,7 @@ export interface LovelyChartParams {
   labelType?: LabelType;
   labelFormatter?: string;
   tooltipFormatter?: string;
+  dateLocale?: DateLocale;
   isStacked?: boolean;
   isPercentage?: boolean;
   withGradient?: boolean;
@@ -94,6 +103,7 @@ export interface AnalyzedData {
   labelType?: LabelType;
   labelFormatter?: string;
   tooltipFormatter?: string;
+  dateLocale?: DateLocale;
   xLabels: XLabel[];
   datasets: AnalyzedDataset[];
   isStacked?: boolean;


### PR DESCRIPTION
Thread an optional `dateLocale` (`{ months, monthsFull, weekDays, weekDaysShort }`) through the data pipeline and date formatters so axis, tooltip and caption labels can render in any language, each field falling back to the English defaults when omitted.

Define the `DateLocale` type, carry it on `AnalyzedData`, and pass it from `Tooltip` and `Zoomer` into `getLabelDate`/`getFullLabelDate` and the month/day formatters. Document the new parameter in the `README`.