### PR TITLE
Zoom: Add `initialZoom` to open a chart pre-zoomed on a point

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Parameter | Description |
 `onZoom`| Optional function which returns `Promise` with data for the zoomed chart (new `data` object)
 `noZoom`| `true` to disable zooming. Default `false`.
 `zoomType`| Chart type shown when a percentage chart is zoomed into a single label: `pie` or `donut`. Default `pie`.
+`initialZoom`| Open the chart already zoomed on a point, with no overview shown and no transition morph: a label index, or `'last'` for the last point. Works for both shares (pie/donut) and custom `onZoom` charts. Zoom-out afterwards behaves normally. Ignored when the chart is not zoomable. Out-of-range indexes are clamped.
 
 ## Contributing
 

--- a/docs/app.js
+++ b/docs/app.js
@@ -42,7 +42,6 @@ document.addEventListener('DOMContentLoaded', () => {
       new LovelyChart(container, chart);
     });
 
-    // Start-zoomed showcases: open directly on the last point (shares → pie, and async `onZoom`)
     new LovelyChart(container, { ...data[5], title: 'Lovely Shares — Start Zoomed', initialZoom: 'last' });
     new LovelyChart(container, { ...data[2], title: 'Lovely Bars — Start Zoomed', initialZoom: 'last' });
   })();

--- a/docs/app.js
+++ b/docs/app.js
@@ -41,6 +41,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
       new LovelyChart(container, chart);
     });
+
+    // Start-zoomed showcases: open directly on the last point (shares → pie, and async `onZoom`)
+    new LovelyChart(container, { ...data[5], title: 'Lovely Shares — Start Zoomed', initialZoom: 'last' });
+    new LovelyChart(container, { ...data[2], title: 'Lovely Bars — Start Zoomed', initialZoom: 'last' });
   })();
 
   document.getElementById('skin-switcher').addEventListener('click', (e) => {

--- a/src/LovelyChart.ts
+++ b/src/LovelyChart.ts
@@ -55,6 +55,9 @@ export default class LovelyChart {
   #windowWidth = window.innerWidth;
   #originalData: LovelyChartParams;
   #isDestroyed = false;
+  // One-shot: the start-zoomed view fires once at construction, never again on
+  // `update()`/resize rebuilds (which would re-jump into zoom unexpectedly)
+  #initialZoomPending = false;
 
   #themeObserver?: MutationObserver;
   #onWindowResize?: () => void;
@@ -70,6 +73,7 @@ export default class LovelyChart {
 
     this.#data = analyzeData(this.#originalData);
     this.#colors = createColors(this.#data.colors);
+    this.#initialZoomPending = this.#data.initialZoomIndex !== undefined;
 
     this.#setupComponents();
     this.#setupGlobalListeners();
@@ -77,6 +81,9 @@ export default class LovelyChart {
 
   update(newData: LovelyChartParams) {
     if (this.#isDestroyed) return;
+    // An explicit data update never (re)triggers the start-zoom — even if the
+    // construction-time zoom has not fired its rAF callback yet
+    this.#initialZoomPending = false;
     this.#originalData = newData;
     this.#destroyComponents();
     const fresh = analyzeData(this.#originalData);
@@ -207,6 +214,14 @@ export default class LovelyChart {
     }
     this.#minimap?.update(state);
     this.#tooltip!.update(state, points, projection, secondaryPoints, secondaryProjection);
+
+    // Start-zoomed: fire once after the first render has set `this.#state` (the
+    // state callback is always rAF-deferred, so setup has completed and the zoomer
+    // exists by now). Jump straight into the requested point with no overview morph.
+    if (this.#initialZoomPending && this.#zoomer && this.#data.initialZoomIndex !== undefined) {
+      this.#initialZoomPending = false;
+      this.#zoomer.zoomIn(state, this.#data.initialZoomIndex, true);
+    }
   };
 
   readonly #onRangeChange = (range: Range) => {

--- a/src/LovelyChart.ts
+++ b/src/LovelyChart.ts
@@ -55,8 +55,6 @@ export default class LovelyChart {
   #windowWidth = window.innerWidth;
   #originalData: LovelyChartParams;
   #isDestroyed = false;
-  // One-shot: the start-zoomed view fires once at construction, never again on
-  // `update()`/resize rebuilds (which would re-jump into zoom unexpectedly)
   #initialZoomPending = false;
 
   #themeObserver?: MutationObserver;
@@ -81,8 +79,6 @@ export default class LovelyChart {
 
   update(newData: LovelyChartParams) {
     if (this.#isDestroyed) return;
-    // An explicit data update never (re)triggers the start-zoom — even if the
-    // construction-time zoom has not fired its rAF callback yet
     this.#initialZoomPending = false;
     this.#originalData = newData;
     this.#destroyComponents();
@@ -215,9 +211,8 @@ export default class LovelyChart {
     this.#minimap?.update(state);
     this.#tooltip!.update(state, points, projection, secondaryPoints, secondaryProjection);
 
-    // Start-zoomed: fire once after the first render has set `this.#state` (the
-    // state callback is always rAF-deferred, so setup has completed and the zoomer
-    // exists by now). Jump straight into the requested point with no overview morph.
+    // The state callback is rAF-deferred, so this is the earliest point where both
+    // `this.#state` and `this.#zoomer` exist — the start-zoom fires here, not in setup
     if (this.#initialZoomPending && this.#zoomer && this.#data.initialZoomIndex !== undefined) {
       this.#initialZoomPending = false;
       this.#zoomer.zoomIn(state, this.#data.initialZoomIndex, true);

--- a/src/Zoomer.ts
+++ b/src/Zoomer.ts
@@ -55,7 +55,7 @@ export class Zoomer {
     this.#tools = tools;
   }
 
-  zoomIn(state: ChartState, labelIndex: number, instant = false) {
+  zoomIn(state: ChartState, labelIndex: number, isInstant = false) {
     if (this.#isZoomed) {
       return;
     }
@@ -68,12 +68,12 @@ export class Zoomer {
     this.#tooltip.toggleIsZoomed(true);
     if (this.#data.shouldZoomToShares) {
       this.#container.classList.add('lovely-chart--state-zoomed-in');
-      // Cancel CSS animation for 'instant' display
-      if (!instant) {
+      // Cancel CSS animation for `isInstant` display
+      if (!isInstant) {
         this.#container.classList.add('lovely-chart--state-animating');
       }
     }
-    if (instant) {
+    if (isInstant) {
       // Hide the freshly-rendered overview until the zoomed view is drawn so it
       // never paints (matters for async `onZoom`, where the swap lands a frame later)
       this.#container.style.visibility = 'hidden';
@@ -86,8 +86,8 @@ export class Zoomer {
     // The custom `onZoom` function may return a rejected promise instead of resolving,
     // which would leave the entire container invisible, so restore it in that case
     void dataPromise.then(
-      (newData) => this.#replaceData(newData, labelIndex, label, instant),
-      () => this.#replaceData(undefined, labelIndex, label, instant),
+      (newData) => this.#replaceData(newData, labelIndex, label, isInstant),
+      () => this.#replaceData(undefined, labelIndex, label, isInstant),
     );
   }
 
@@ -126,7 +126,7 @@ export class Zoomer {
   }
 
   #replaceData(
-    newRawData: LovelyChartParams | undefined, labelIndex: number, zoomInLabel?: XLabel, instant = false,
+    newRawData: LovelyChartParams | undefined, labelIndex: number, zoomInLabel?: XLabel, isInstant = false,
   ) {
     if (this.#isDestroyed) return;
 
@@ -135,7 +135,7 @@ export class Zoomer {
       this.#tooltip.toggleIsZoomed(false);
       this.#header.toggleIsZooming(false);
       // Reveal the overview fallback so the chart is not stuck hidden
-      if (instant) {
+      if (isInstant) {
         this.#container.style.visibility = '';
       }
 
@@ -147,7 +147,7 @@ export class Zoomer {
     const newData = analyzeData(newRawData, this.#isZoomed || this.#data.shouldZoomToShares ? 'day' : 'hour');
     const shouldZoomToLines = Object.keys(this.#data.datasets).length !== Object.keys(newData.datasets).length;
 
-    if (instant) {
+    if (isInstant) {
       this.#applyZoomData(newData, newRawData, shouldZoomToLines, zoomInLabel, true);
       this.#container.style.visibility = '';
 
@@ -185,7 +185,7 @@ export class Zoomer {
     newRawData: LovelyChartParams,
     shouldZoomToLines: boolean,
     zoomInLabel: XLabel | undefined,
-    instant: boolean,
+    isInstant: boolean,
   ) {
     Object.assign(this.#data, newData);
 
@@ -238,7 +238,7 @@ export class Zoomer {
       }
     }
 
-    if (instant) {
+    if (isInstant) {
       this.#stateManager.update({
         range,
         filter,

--- a/src/Zoomer.ts
+++ b/src/Zoomer.ts
@@ -55,7 +55,8 @@ export class Zoomer {
     this.#tools = tools;
   }
 
-  zoomIn(state: ChartState, labelIndex: number) {
+  // `instant` opens directly in the final zoomed view, with no overview morph
+  zoomIn(state: ChartState, labelIndex: number, instant = false) {
     if (this.#isZoomed) {
       return;
     }
@@ -68,14 +69,27 @@ export class Zoomer {
     this.#tooltip.toggleIsZoomed(true);
     if (this.#data.shouldZoomToShares) {
       this.#container.classList.add('lovely-chart--state-zoomed-in');
-      this.#container.classList.add('lovely-chart--state-animating');
+      // `state-animating` drives the CSS circle morph — skipped for the instant view
+      if (!instant) {
+        this.#container.classList.add('lovely-chart--state-animating');
+      }
+    }
+    if (instant) {
+      // Hide the freshly-rendered overview until the zoomed view is drawn so it
+      // never paints (matters for async `onZoom`, where the swap lands a frame later)
+      this.#container.style.visibility = 'hidden';
     }
 
     const { value } = label;
     const dataPromise = this.#data.shouldZoomToShares
       ? Promise.resolve(this.#generateCircleData(labelIndex))
       : this.#data.onZoom!(value);
-    void dataPromise.then((newData) => this.#replaceData(newData, labelIndex, label));
+    // A rejected `onZoom` is treated like resolved-`undefined`: abort the zoom and
+    // (in the instant path) reveal the container instead of leaving it hidden forever
+    void dataPromise.then(
+      (newData) => this.#replaceData(newData, labelIndex, label, instant),
+      () => this.#replaceData(undefined, labelIndex, label, instant),
+    );
   }
 
   zoomOut(state: ChartState) {
@@ -112,25 +126,40 @@ export class Zoomer {
     }
   }
 
-  #replaceData(newRawData: LovelyChartParams | undefined, labelIndex: number, zoomInLabel?: XLabel) {
+  #replaceData(
+    newRawData: LovelyChartParams | undefined, labelIndex: number, zoomInLabel?: XLabel, instant = false,
+  ) {
     if (this.#isDestroyed) return;
 
     if (!newRawData) {
       this.#tooltip.toggleLoading(false);
       this.#tooltip.toggleIsZoomed(false);
       this.#header.toggleIsZooming(false);
+      // Reveal the overview fallback so the chart is not stuck hidden
+      if (instant) {
+        this.#container.style.visibility = '';
+      }
 
       return;
     }
 
     this.#tooltip.toggleLoading(false);
 
+    const newData = analyzeData(newRawData, this.#isZoomed || this.#data.shouldZoomToShares ? 'day' : 'hour');
+    const shouldZoomToLines = Object.keys(this.#data.datasets).length !== Object.keys(newData.datasets).length;
+
+    if (instant) {
+      // Jump to the zoomed view in place (no collapse morph), then reveal it
+      this.#applyZoomData(newData, newRawData, shouldZoomToLines, zoomInLabel, true);
+      this.#container.style.visibility = '';
+
+      return;
+    }
+
     const labelWidth = 1 / this.#data.xLabels.length;
     const labelMiddle = getLabelFraction(labelIndex, this.#data.xLabels.length - 1);
     const filter: Filter = {};
     this.#data.datasets.forEach(({ key }) => filter[key] = false);
-    const newData = analyzeData(newRawData, this.#isZoomed || this.#data.shouldZoomToShares ? 'day' : 'hour');
-    const shouldZoomToLines = Object.keys(this.#data.datasets).length !== Object.keys(newData.datasets).length;
 
     this.#stateManager.update({
       range: {
@@ -142,57 +171,87 @@ export class Zoomer {
 
     this.#swapDataTimeout = window.setTimeout(() => {
       this.#swapDataTimeout = undefined;
-      Object.assign(this.#data, newData);
+      this.#applyZoomData(newData, newRawData, shouldZoomToLines, zoomInLabel, false);
+    }, this.#stateManager.hasAnimations() ? ZOOM_TIMEOUT : 0);
 
-      if (shouldZoomToLines && newRawData.colors) {
-        Object.assign(this.#colors, createColors(newRawData.colors));
+    this.#stateAnimatingTimeout = window.setTimeout(() => {
+      this.#stateAnimatingTimeout = undefined;
+      if (this.#data.shouldZoomToShares) {
+        this.#container.classList.remove('lovely-chart--state-animating');
       }
+    }, this.#stateManager.hasAnimations() ? ZOOM_ANIMATING_TIMEOUT : 0);
+  }
 
-      if (shouldZoomToLines) {
-        this.#minimap?.toggle(this.#isZoomed);
-        this.#tools.redraw();
-        this.#container.style.width = `${this.#container.scrollWidth}px`;
-        this.#container.style.height = `${this.#container.scrollHeight}px`;
-      }
+  // Swaps in the zoomed dataset and applies the final range/filter. Shared by the
+  // click-driven morph (`instant=false`, called after the collapse timeout) and the
+  // start-zoomed path (`instant=true`, jumps with no transition).
+  #applyZoomData(
+    newData: AnalyzedData,
+    newRawData: LovelyChartParams,
+    shouldZoomToLines: boolean,
+    zoomInLabel: XLabel | undefined,
+    instant: boolean,
+  ) {
+    Object.assign(this.#data, newData);
 
-      const daysCount = this.#isZoomed || this.#data.shouldZoomToShares
-        ? this.#data.xLabels.length
-        : this.#data.xLabels.length / 24;
-      const halfDayWidth = (1 / daysCount) / 2;
-      const centeredDayRange = {
-        begin: ZOOM_RANGE_MIDDLE - halfDayWidth,
-        end: ZOOM_RANGE_MIDDLE + halfDayWidth,
+    if (shouldZoomToLines && newRawData.colors) {
+      Object.assign(this.#colors, createColors(newRawData.colors));
+    }
+
+    if (shouldZoomToLines) {
+      this.#minimap?.toggle(this.#isZoomed);
+      this.#tools.redraw();
+      this.#container.style.width = `${this.#container.scrollWidth}px`;
+      this.#container.style.height = `${this.#container.scrollHeight}px`;
+    }
+
+    const daysCount = this.#isZoomed || this.#data.shouldZoomToShares
+      ? this.#data.xLabels.length
+      : this.#data.xLabels.length / 24;
+    const halfDayWidth = (1 / daysCount) / 2;
+    const centeredDayRange = {
+      begin: ZOOM_RANGE_MIDDLE - halfDayWidth,
+      end: ZOOM_RANGE_MIDDLE + halfDayWidth,
+    };
+
+    let range: Range;
+    let filter: Filter;
+
+    if (this.#isZoomed) {
+      range = {
+        begin: this.#stateBeforeZoomIn!.begin,
+        end: this.#stateBeforeZoomIn!.end,
       };
-
-      let range: Range;
-      let filter: Filter;
-
-      if (this.#isZoomed) {
+      filter = shouldZoomToLines ? this.#stateBeforeZoomIn!.filter : this.#stateBeforeZoomOut!.filter;
+    } else {
+      if (shouldZoomToLines) {
         range = {
-          begin: this.#stateBeforeZoomIn!.begin,
-          end: this.#stateBeforeZoomIn!.end,
+          begin: 0,
+          end: 1,
         };
-        filter = shouldZoomToLines ? this.#stateBeforeZoomIn!.filter : this.#stateBeforeZoomOut!.filter;
+        filter = {};
+        this.#data.datasets.forEach(({ key }) => filter[key] = true);
       } else {
-        if (shouldZoomToLines) {
-          range = {
-            begin: 0,
-            end: 1,
-          };
-          filter = {};
-          this.#data.datasets.forEach(({ key }) => filter[key] = true);
-        } else {
-          // The clicked day is not necessarily in the window middle — at the data
-          // edges the window is clamped, so the day is located by timestamp
-          range = this.#data.shouldZoomToShares
-            ? this.#buildDayRange(newData.xLabels, zoomInLabel!.value) ?? centeredDayRange
-            : newData.minimapRange
-              ?? this.#buildDayRange(newData.xLabels, zoomInLabel!.value)
-              ?? centeredDayRange;
-          filter = this.#stateBeforeZoomIn!.filter;
-        }
+        // The clicked day is not necessarily in the window middle — at the data
+        // edges the window is clamped, so the day is located by timestamp
+        range = this.#data.shouldZoomToShares
+          ? this.#buildDayRange(newData.xLabels, zoomInLabel!.value) ?? centeredDayRange
+          : newData.minimapRange
+            ?? this.#buildDayRange(newData.xLabels, zoomInLabel!.value)
+            ?? centeredDayRange;
+        filter = this.#stateBeforeZoomIn!.filter;
       }
+    }
 
+    if (instant) {
+      // Jump straight to the final zoomed range/filter with no transition
+      this.#stateManager.update({
+        range,
+        filter,
+        focusOn: NO_FOCUS,
+        minimapDelta: this.#isZoomed ? 0 : range.end - range.begin,
+      }, true);
+    } else {
       // For shares zoom the range is applied directly: animating it from the
       // placeholder would draw the circle from wrong label windows (and thus wrong
       // slice proportions) during the CSS transition
@@ -210,21 +269,14 @@ export class Zoomer {
         // 0 disables discrete range snapping (when zooming back out)
         minimapDelta: this.#isZoomed ? 0 : range.end - range.begin,
       });
+    }
 
-      if (zoomInLabel) {
-        this.#header.zoom(getFullLabelDate(zoomInLabel));
-      }
+    if (zoomInLabel) {
+      this.#header.zoom(getFullLabelDate(zoomInLabel));
+    }
 
-      this.#isZoomed = !this.#isZoomed;
-      this.#header.toggleIsZooming(false);
-    }, this.#stateManager.hasAnimations() ? ZOOM_TIMEOUT : 0);
-
-    this.#stateAnimatingTimeout = window.setTimeout(() => {
-      this.#stateAnimatingTimeout = undefined;
-      if (this.#data.shouldZoomToShares) {
-        this.#container.classList.remove('lovely-chart--state-animating');
-      }
-    }, this.#stateManager.hasAnimations() ? ZOOM_ANIMATING_TIMEOUT : 0);
+    this.#isZoomed = !this.#isZoomed;
+    this.#header.toggleIsZooming(false);
   }
 
   // The hourly window in zoomed data may be clamped at the data edges, so the

--- a/src/Zoomer.ts
+++ b/src/Zoomer.ts
@@ -55,7 +55,6 @@ export class Zoomer {
     this.#tools = tools;
   }
 
-  // `instant` opens directly in the final zoomed view, with no overview morph
   zoomIn(state: ChartState, labelIndex: number, instant = false) {
     if (this.#isZoomed) {
       return;
@@ -69,7 +68,7 @@ export class Zoomer {
     this.#tooltip.toggleIsZoomed(true);
     if (this.#data.shouldZoomToShares) {
       this.#container.classList.add('lovely-chart--state-zoomed-in');
-      // `state-animating` drives the CSS circle morph — skipped for the instant view
+      // Cancel CSS animation for 'instant' display
       if (!instant) {
         this.#container.classList.add('lovely-chart--state-animating');
       }
@@ -84,8 +83,8 @@ export class Zoomer {
     const dataPromise = this.#data.shouldZoomToShares
       ? Promise.resolve(this.#generateCircleData(labelIndex))
       : this.#data.onZoom!(value);
-    // A rejected `onZoom` is treated like resolved-`undefined`: abort the zoom and
-    // (in the instant path) reveal the container instead of leaving it hidden forever
+    // The custom `onZoom` function may return a rejected promise instead of resolving,
+    // which would leave the entire container invisible, so restore it in that case
     void dataPromise.then(
       (newData) => this.#replaceData(newData, labelIndex, label, instant),
       () => this.#replaceData(undefined, labelIndex, label, instant),
@@ -149,7 +148,6 @@ export class Zoomer {
     const shouldZoomToLines = Object.keys(this.#data.datasets).length !== Object.keys(newData.datasets).length;
 
     if (instant) {
-      // Jump to the zoomed view in place (no collapse morph), then reveal it
       this.#applyZoomData(newData, newRawData, shouldZoomToLines, zoomInLabel, true);
       this.#container.style.visibility = '';
 
@@ -182,9 +180,6 @@ export class Zoomer {
     }, this.#stateManager.hasAnimations() ? ZOOM_ANIMATING_TIMEOUT : 0);
   }
 
-  // Swaps in the zoomed dataset and applies the final range/filter. Shared by the
-  // click-driven morph (`instant=false`, called after the collapse timeout) and the
-  // start-zoomed path (`instant=true`, jumps with no transition).
   #applyZoomData(
     newData: AnalyzedData,
     newRawData: LovelyChartParams,
@@ -244,7 +239,6 @@ export class Zoomer {
     }
 
     if (instant) {
-      // Jump straight to the final zoomed range/filter with no transition
       this.#stateManager.update({
         range,
         filter,

--- a/src/data.ts
+++ b/src/data.ts
@@ -42,7 +42,7 @@ export function analyzeData(data: LovelyChartParams, fallbackLabelType?: LabelTy
   const {
     title, labelFormatter: labelFormatterRaw, tooltipFormatter, isStacked, isPercentage, secondaryYAxis,
     hasSecondYAxis, onZoom, noZoom, zoomType, withMinimap, minimapRange, noCaption, zoomOutLabel,
-    valuePrefix, valueSuffix, isCurrencyPrefix, limitDate, onLimitedRangeClick,
+    valuePrefix, valueSuffix, isCurrencyPrefix, limitDate, onLimitedRangeClick, initialZoom,
   } = data;
   const isPie = data.type === 'pie';
   const isDonut = data.type === 'donut';
@@ -101,6 +101,7 @@ export function analyzeData(data: LovelyChartParams, fallbackLabelType?: LabelTy
   }
 
   const shouldZoomToShares = !onZoom && !noZoom && Boolean(isPercentage);
+  const isZoomable = !noZoom && (Boolean(onZoom) || shouldZoomToShares);
 
   const analyzed: AnalyzedData = {
     title,
@@ -137,7 +138,8 @@ export function analyzeData(data: LovelyChartParams, fallbackLabelType?: LabelTy
     onLimitedRangeClick,
     shouldZoomToShares,
     zoomType: zoomType || 'pie',
-    isZoomable: !noZoom && (Boolean(onZoom) || shouldZoomToShares),
+    isZoomable,
+    initialZoomIndex: resolveInitialZoomIndex(initialZoom, isZoomable, xLabels.length),
   };
 
   return analyzed;
@@ -199,6 +201,28 @@ function buildMinimapRange(minimapRange?: [number, number] | 'full'): Range | un
 
   const [begin, end] = minimapRange;
   return { begin, end };
+}
+
+// Resolves the `initialZoom` param to a clamped label index, or `undefined` when not
+// applicable (non-zoomable chart or empty series); out-of-range indexes are clamped
+function resolveInitialZoomIndex(
+  initialZoom: number | 'last' | undefined,
+  isZoomable: boolean,
+  labelsCount: number,
+): number | undefined {
+  if (initialZoom === undefined || !isZoomable || labelsCount === 0) {
+    return undefined;
+  }
+
+  if (initialZoom === 'last') {
+    return labelsCount - 1;
+  }
+
+  if (typeof initialZoom !== 'number') {
+    return undefined;
+  }
+
+  return Math.max(0, Math.min(Math.round(initialZoom), labelsCount - 1));
 }
 
 function prepareDatasets(data: LovelyChartParams): { labels: (number | string)[]; datasets: AnalyzedDataset[] } {

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,7 @@ export interface LovelyChartParams {
   onZoom?: (value: number) => Promise<LovelyChartParams | undefined>;
   noZoom?: boolean;
   zoomType?: 'pie' | 'donut';
+  initialZoom?: number | 'last';
   withMinimap?: boolean;
   minimapRange?: [number, number] | 'full';
   noCaption?: boolean;
@@ -125,6 +126,7 @@ export interface AnalyzedData {
   shouldZoomToShares: boolean;
   zoomType: 'pie' | 'donut';
   isZoomable: boolean;
+  initialZoomIndex?: number;
 }
 
 export interface ChartState {

--- a/test/e2e.js
+++ b/test/e2e.js
@@ -123,7 +123,7 @@ async function drag(page, x, y, dx, dy, steps = 10) {
 
   // --- Rendering ---
   const count = await charts.count();
-  check('all demo charts created', count === 8, `got ${count}`);
+  check('all demo charts created', count === 10, `got ${count}`);
 
   for (let i = 0; i < count; i++) {
     const painted = await paintedPixels(page, i);
@@ -226,6 +226,41 @@ async function drag(page, x, y, dx, dy, steps = 10) {
   const pieText = (await pieBalloon.textContent()).trim();
   check('pie sector hover shows tooltip', pieShown && pieText.length > 0, JSON.stringify(pieText.slice(0, 40)));
 
+  // --- Start-zoomed init (chart 8: shares, opened already as a pie, no morph) ---
+  const startZoomed = charts.nth(8);
+  await startZoomed.scrollIntoViewIfNeeded();
+  const startedZoomed = await startZoomed.evaluate((el) =>
+    el.classList.contains('lovely-chart--state-zoomed-in'));
+  const startZoomOut = startZoomed.locator('.lovely-chart--header-zoom-out-control');
+  const hasZoomOut = (await startZoomOut.count()) > 0;
+  check('start-zoomed shares opens already zoomed', startedZoomed && hasZoomOut,
+    `zoomed-in: ${startedZoomed}, zoom-out control: ${hasZoomOut}`);
+
+  if (hasZoomOut) {
+    await startZoomOut.first().click();
+    await sleep(2000);
+    const stillZoomed = await startZoomed.evaluate((el) =>
+      el.classList.contains('lovely-chart--state-zoomed-in'));
+    check('start-zoomed zoom-out returns to overview', !stillZoomed, `still zoomed: ${stillZoomed}`);
+  }
+
+  // --- Start-zoomed init (chart 9: async onZoom, opened already on the zoomed day) ---
+  const startZoomedAsync = charts.nth(9);
+  await startZoomedAsync.scrollIntoViewIfNeeded();
+  const asyncZoomOut = startZoomedAsync.locator('.lovely-chart--header-zoom-out-control');
+  const asyncHasZoomOut = (await asyncZoomOut.count()) > 0;
+  const asyncCaption = await startZoomedAsync.locator('.lovely-chart--header-caption').textContent();
+  // A zoomed day caption is a single date; the overview caption is a "start — end" range
+  check('start-zoomed onZoom opens already zoomed', asyncHasZoomOut && !asyncCaption.includes('—'),
+    `zoom-out: ${asyncHasZoomOut}, caption: ${JSON.stringify(asyncCaption)}`);
+
+  if (asyncHasZoomOut) {
+    await asyncZoomOut.first().click();
+    await sleep(2000);
+    const backCaption = await startZoomedAsync.locator('.lovely-chart--header-caption').textContent();
+    check('start-zoomed onZoom zoom-out returns to overview', backCaption.includes('—'), JSON.stringify(backCaption));
+  }
+
   // --- Theme switch (MutationObserver -> state update path) ---
   await page.locator('#skin-switcher').click();
   await sleep(800);
@@ -236,7 +271,7 @@ async function drag(page, x, y, dx, dy, steps = 10) {
   await sleep(1200);
   const countAfterResize = await page.locator('.lovely-chart--container').count();
   const paintedAfterResize = await paintedPixels(page, 0);
-  check('resize redraw keeps all charts alive', countAfterResize === 8 && paintedAfterResize > 1000,
+  check('resize redraw keeps all charts alive', countAfterResize === 10 && paintedAfterResize > 1000,
     `charts: ${countAfterResize}, painted: ${paintedAfterResize}px`);
 
   // --- Console hygiene ---


### PR DESCRIPTION
New optional `initialZoom` param (a label index or `'last'`) opens the chart already zoomed on a point, with no overview shown and no transition morph. Works for both shares (pie/donut) and custom `onZoom` charts; zoom-out afterwards behaves normally. Ignored when the chart is not zoomable and out-of-range indexes are clamped.

- data.ts: resolve `initialZoom` into a clamped `initialZoomIndex`
- Zoomer.zoomIn: support an immediate, no-morph zoom path
- LovelyChart: fire the zoom once after first render, never on later `update()`/resize rebuilds
- docs: two start-zoomed showcase charts; e2e count 8 -> 10